### PR TITLE
Normalize Sanitizer configuration by lowercasing all element names in element lists, and filtering unsupported keys and elements

### DIFF
--- a/src/sanitizer.js
+++ b/src/sanitizer.js
@@ -34,24 +34,27 @@ export const _normalizeConfig = function _normalizeConfig(config) {
     config = {};
   }
 
-  config = Object.keys(config).filter((key) => {
-    return supportedConfigurationLists.has(key);
-  });
-
+  let normalizedConfig = {};
   // TODO https://github.com/mozilla/sanitizer-polyfill/issues/29
   for (let [configurationElementList, elements] of Object.entries(config)) {
-    config[configurationElementList] = elements.map((element) => {
-      return element.toLowerCase();
-    });
+    if (supportedConfigurationLists.has(configurationElementList)) {
+      normalizedConfig[configurationElementList] = elements.map((element) => {
+        return element.toLowerCase();
+      });
+    }
   }
 
-  const allowElements = config.allowElements || DEFAULT_ALLOWED_ELEMENTS;
-  const allowAttributes = config.allowAttributes || DEFAULT_ALLOWED_ATTRIBUTES;
-  const blockElements = config.blockElements || DEFAULT_BLOCKED_ELEMENTS;
-  const dropElements = config.dropElements || DEFAULT_DROP_ELEMENTS;
-  const dropAttributes = config.dropAttributes || DEFAULT_DROP_ATTRIBUTES;
-  const allowComments = !!config.allowComments;
-  const allowCustomElements = !!config.allowCustomElements;
+  const allowElements =
+    normalizedConfig.allowElements || DEFAULT_ALLOWED_ELEMENTS;
+  const allowAttributes =
+    normalizedConfig.allowAttributes || DEFAULT_ALLOWED_ATTRIBUTES;
+  const blockElements =
+    normalizedConfig.blockElements || DEFAULT_BLOCKED_ELEMENTS;
+  const dropElements = normalizedConfig.dropElements || DEFAULT_DROP_ELEMENTS;
+  const dropAttributes =
+    normalizedConfig.dropAttributes || DEFAULT_DROP_ATTRIBUTES;
+  const allowComments = !!normalizedConfig.allowComments;
+  const allowCustomElements = !!normalizedConfig.allowCustomElements;
   return {
     allowElements,
     allowAttributes,

--- a/src/sanitizer.js
+++ b/src/sanitizer.js
@@ -38,6 +38,7 @@ export const _normalizeConfig = function _normalizeConfig(config) {
     return supportedConfigurationLists.has(key);
   });
 
+  // TODO https://github.com/mozilla/sanitizer-polyfill/issues/29
   for (let [configurationElementList, elements] of Object.entries(config)) {
     config[configurationElementList] = elements.map((element) => {
       return element.toLowerCase();

--- a/src/sanitizer.js
+++ b/src/sanitizer.js
@@ -33,11 +33,17 @@ export const _normalizeConfig = function _normalizeConfig(config) {
   ) {
     config = {};
   }
+
+  config = Object.keys(config).filter((key) => {
+    return supportedConfigurationLists.has(key);
+  });
+
   for (let [configurationElementList, elements] of Object.entries(config)) {
     config[configurationElementList] = elements.map((element) => {
       return element.toLowerCase();
     });
   }
+
   const allowElements = config.allowElements || DEFAULT_ALLOWED_ELEMENTS;
   const allowAttributes = config.allowAttributes || DEFAULT_ALLOWED_ATTRIBUTES;
   const blockElements = config.blockElements || DEFAULT_BLOCKED_ELEMENTS;
@@ -74,6 +80,16 @@ const _transformConfig = function transformConfig(config) {
     FORBID_ATTR: dropAttrs,
   };
 };
+
+const supportedConfigurationLists = new Set([
+  "allowElements",
+  "blockElements",
+  "dropElements",
+  "allowAttributes",
+  "dropAttributes",
+  "allowCustomElements",
+  "allowComments",
+]);
 
 // from https://wicg.github.io/sanitizer-api/#constants
 const DEFAULT_ALLOWED_ELEMENTS = [

--- a/src/sanitizer.js
+++ b/src/sanitizer.js
@@ -26,8 +26,17 @@ export const sanitizeDocFragment = function _sanitizeDocFragment(
  * @private
  */
 export const _normalizeConfig = function _normalizeConfig(config) {
-  if (!config) {
+  if (
+    config &&
+    Object.keys(config).length === 0 &&
+    config.constructor === Object
+  ) {
     config = {};
+  }
+  for (let [configurationElementList, elements] of Object.entries(config)) {
+    config[configurationElementList] = elements.map((element) => {
+      return element.toLowerCase();
+    });
   }
   const allowElements = config.allowElements || DEFAULT_ALLOWED_ELEMENTS;
   const allowAttributes = config.allowAttributes || DEFAULT_ALLOWED_ATTRIBUTES;

--- a/src/sanitizer.js
+++ b/src/sanitizer.js
@@ -37,10 +37,20 @@ export const _normalizeConfig = function _normalizeConfig(config) {
   let normalizedConfig = {};
   // TODO https://github.com/mozilla/sanitizer-polyfill/issues/29
   for (let [configurationElementList, elements] of Object.entries(config)) {
-    if (supportedConfigurationLists.has(configurationElementList)) {
+    if (SUPPORTED_CONFIGURATION_LISTS.has(configurationElementList)) {
       normalizedConfig[configurationElementList] = elements.map((element) => {
         return element.toLowerCase();
       });
+      if (configurationElementList === "allowElements") {
+        const defaultAllowedElementsSet = new Set(DEFAULT_ALLOWED_ELEMENTS);
+        normalizedConfig[configurationElementList].forEach((element) => {
+          if (!defaultAllowedElementsSet.has(element)) {
+            throw new SanitizerConfigurationError(
+              `${element} is not included in built-in element allow list`
+            );
+          }
+        });
+      }
     }
   }
 
@@ -85,7 +95,14 @@ const _transformConfig = function transformConfig(config) {
   };
 };
 
-const supportedConfigurationLists = new Set([
+class SanitizerConfigurationError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "SanitizerConfigurationError";
+  }
+}
+
+const SUPPORTED_CONFIGURATION_LISTS = new Set([
   "allowElements",
   "blockElements",
   "dropElements",


### PR DESCRIPTION
From [HTML Sanitizer API spec](https://wicg.github.io/sanitizer-api/#config): "Note: Element names are expected to be ascii lowercase and those that don’t conform will be lowercased."

Also addressing the following from https://github.com/mozilla/sanitizer-polyfill/issues/5:
> we should drop all unexpected key/values in that object
