### PR TITLE
Include sanitizing context element

### DIFF
--- a/src/polyfill.js
+++ b/src/polyfill.js
@@ -52,11 +52,11 @@ function setup() {
          * @returns {Node} DocumentFragment
          */
         sanitizeFor(localName, input) {
-          // TODO: issue #19: this should parse/sanitize/filter/validate bad values for localName
           // The inactive document does not issue requests and does not execute scripts.
           const inactiveDocument = document.implementation.createHTMLDocument();
           const context = inactiveDocument.createElement(localName);
           context.innerHTML = input;
+          this.config.WHOLE_DOCUMENT = true; //set to sanitize bad values for localName
           sanitizeDocFragment(this.config, context);
           return context;
         },

--- a/src/polyfill.js
+++ b/src/polyfill.js
@@ -45,6 +45,12 @@ function setup() {
           }
           return new TypeError("Can't Sanitize input of type " + input.prototype);
         }, */
+
+        /*
+         * @param {string} localName - name of context element
+         * @param {Node} input - a document fragment to be sanitized
+         * @returns {Node} DocumentFragment
+         */
         sanitizeFor(localName, input) {
           // TODO: issue #19: this should parse/sanitize/filter/validate bad values for localName
           // The inactive document does not issue requests and does not execute scripts.

--- a/src/sanitizer.js
+++ b/src/sanitizer.js
@@ -56,12 +56,12 @@ export const _normalizeConfig = function _normalizeConfig(config) {
   };
 };
 
-// /**
-//  * transform a Sanitizer-API-shaped configuration object into a config for DOMPurify invocation
-//  * @param config
-//  * @return {object} - a DOMPurify-compatible configuration object
-//  * @private
-//  */
+/**
+ * transform a Sanitizer-API-shaped configuration object into a config for DOMPurify invocation
+ * @param {object} config - a configuration object
+ * @returns {object} - a DOMPurify-compatible configuration object
+ * @private
+ */
 const _transformConfig = function transformConfig(config) {
   const allowElems = config.allowElements || [];
   const allowAttrs = config.allowAttributes || [];

--- a/src/sanitizer.js
+++ b/src/sanitizer.js
@@ -26,8 +26,17 @@ export const sanitizeDocFragment = function _sanitizeDocFragment(
  * @private
  */
 export const _normalizeConfig = function _normalizeConfig(config) {
-  if (!config) {
+  if (
+    config &&
+    Object.keys(config).length === 0 &&
+    config.constructor === Object
+  ) {
     config = {};
+  }
+  for (let [configurationElementList, elements] of Object.entries(config)) {
+    config[configurationElementList] = elements.map((element) => {
+      return element.toLowerCase();
+    });
   }
   const allowElements = config.allowElements || DEFAULT_ALLOWED_ELEMENTS;
   const allowAttributes = config.allowAttributes || DEFAULT_ALLOWED_ATTRIBUTES;


### PR DESCRIPTION
I understood https://github.com/mozilla/sanitizer-polyfill/issues/19 as we don't to sanitize [the context element](https://github.com/mozilla/sanitizer-polyfill/blob/main/src/polyfill.js#L52) we append the user's input to, but we want the context element to be sanitized alongside the user input. 

Please let me know if I misunderstood and the issue is actually referencing a different problem

## Test plan
```javascript
let parser = new DOMParser();
let doc = parser.parseFromString('<body onload=alert(1)><p>hi! <svg/onload="alert(1)" />well <em>please</em> <a href="javascript:alert(2)" title="pretty-please">click me!</a><body>', 'text/html');
// Current sanitizeFor behavior (the body tag is gone)
DOMPurify.sanitize(doc.querySelector('body')) // returns "<p>hi! <svg></svg>well <em>please</em> <a title="pretty-please">click me!</a></p>"
// sanitizeFor including sanitizing context element (onload attribute is gone, but the body tag remains)
DOMPurify.sanitize(doc.querySelector('body'), {"WHOLE_DOCUMENT": true}) // returns "<body><p>hi! <svg></svg>well <em>please</em> <a title="pretty-please">click me!</a></p></body>"
```

The caveat of this approach is that `sanitizeFor` will return a `HTMLHtmlElement`, instead of a `DocumentFragment`, but since we have a reference to the context element, we can select context node and all its children to recreate the DocumentFragment. For example:
```javascript
let parser = new DOMParser();
let doc = parser.parseFromString('<table><body onload=alert(1)><p>hi! <svg/onload="alert(1)" />well <em>please</em> <a href="javascript:alert(2)" title="pretty-please">click me!</a><body></table>', 'text/html');
DOMPurify.sanitize(doc.querySelector('table')) // returns DocumentFragment containing "<table></table>"
DOMPurify.sanitize(doc.querySelector('body'), {"WHOLE_DOCUMENT": true}) // returns HTMLHtmlElement containing "<html><head></head><body></body><table></table></html>"
```

Also these tests might not be the best since I choose to use wrap the input around a `body` tag. I'll see if I can come up with a better element to use as the context element