### PR TITLE
Change DOMPurify `FORBID_TAGS` to reference `blockElements`

### DIFF
--- a/src/sanitizer.js
+++ b/src/sanitizer.js
@@ -56,12 +56,12 @@ export const _normalizeConfig = function _normalizeConfig(config) {
 const _transformConfig = function transformConfig(config) {
   const allowElems = config.allowElements || [];
   const allowAttrs = config.allowAttributes || [];
-  const dropElems = config.dropElements || [];
+  const blockElements = config.blockElements || [];
   const dropAttrs = config.dropAttributes || [];
   return {
     ALLOWED_TAGS: allowElems,
     ALLOWED_ATTR: allowAttrs,
-    FORBID_TAGS: dropElems,
+    FORBID_TAGS: blockElements,
     FORBID_ATTR: dropAttrs,
   };
 };


### PR DESCRIPTION
It seems like `FORBID_TAGS` in DOMPurify config better fits what we want for `blockElements` than `dropElements`

Example:
```javascript
// https://wicg.github.io/sanitizer-api/#example-665b3412
const sample = "Some text <b><i>with</i></b> <blink>tags</blink>.";  

// Expected:
new Sanitizer({dropElements: [ "b" ]).sanitize(sample); // returns "Some text <blink>tags</blink>."

// Actual:
DOMPurify.sanitize(sample, {FORBID_TAGS: ["b"]}); // returns "Some text <i>with</i> <blink>tags</blink>."
new Sanitizer({blockElements: [ "b" ]).sanitize(sample); // returns "Some text <i>with</i> <blink>tags</blink>."
```

[Live DOM Viewer link](https://livedom.lab.xss.academy/#%7B%22input%22%3A%22Some%20text%20%3Cb%3E%3Ci%3Ewith%3C%2Fi%3E%3C%2Fb%3E%20%3Cblink%3Etags%3C%2Fblink%3E.%22%2C%22customParser%22%3A%22class%20DOMPurifier%20%7B%20%5Cn%20%20%20%20init()%20%7B%5Cn%20%20%20%20%20%20%20%20const%20s%20%3D%20document.createElement('script')%3B%5Cn%20%20%20%20%20%20%20%20s.src%20%3D%20'https%3A%2F%2Fcure53.de%2Fpurify.js'%3B%5Cn%20%20%20%20%20%20%20%20document.head.append(s)%3B%5Cn%20%20%20%20%7D%5Cn%20%20%20%20parse(s)%20%7B%20%5Cn%20%20%20%20%20%20%20%20display(new%20DOMParser().parseFromString(s%2C%20'text%2Fhtml')%2C%20'Before%20sanitization')%3B%5Cn%20%20%20%20%20%20%20%20const%20sanitized%20%3D%20DOMPurify.sanitize(s%2C%20%7BFORBID_TAGS%3A%20%5B%5C%22b%5C%22%5D%7D)%3B%5Cn%20%20%20%20%20%20%20%20display(sanitized%2C%20'Sanitized%20string')%3B%5Cn%20%20%20%20%20%20%20%20display(new%20DOMParser().parseFromString(sanitized%2C%20'text%2Fhtml')%2C%20'Sanitized%20string%20as%20DOM')%3B%5Cn%20%20%20%20%7D%20%5Cn%7D%22%7D)
