### PR TITLE
Implement `Sanitizer.getDefaultConfiguration()`

### DIFF
--- a/src/polyfill.js
+++ b/src/polyfill.js
@@ -67,9 +67,11 @@ function setup() {
         getConfiguration() {
           return normalizedConfig;
         },
-        getDefaultConfiguration: getDefaultConfiguration(),
       });
       return Object.freeze(api);
+    };
+    sanitizer.getDefaultConfiguration = function () {
+      return getDefaultConfiguration();
     };
     window[GLOBALNAME] = sanitizer;
     HTMLElement.prototype[SETTER_NAME] = function setHTML(input, sanitizerObj) {

--- a/src/polyfill.js
+++ b/src/polyfill.js
@@ -5,6 +5,7 @@
 
 import {
   DEFAULT_ALLOWED_ELEMENTS,
+  getDefaultConfiguration,
   sanitizeDocFragment,
   _normalizeConfig,
 } from "../src/sanitizer.js";
@@ -66,6 +67,7 @@ function setup() {
         getConfiguration() {
           return normalizedConfig;
         },
+        getDefaultConfiguration: getDefaultConfiguration(),
       });
       return Object.freeze(api);
     };

--- a/src/sanitizer.js
+++ b/src/sanitizer.js
@@ -31,7 +31,7 @@ export const _normalizeConfig = function _normalizeConfig(config) {
     Object.keys(config).length === 0 &&
     config.constructor === Object
   ) {
-    config = {};
+    return getDefaultConfiguration();
   }
 
   let normalizedConfig = {};
@@ -73,6 +73,45 @@ export const _normalizeConfig = function _normalizeConfig(config) {
     allowCustomElements,
     allowComments,
   };
+};
+
+/**
+ * return default sanitizer API configuration defined by the spec - https://wicg.github.io/sanitizer-api/#default-configuration
+ * @returns {object} - default sanitizer API config
+ */
+export const getDefaultConfiguration = function getDefaultConfiguration() {
+  // https://wicg.github.io/sanitizer-api/#ref-for-default-configuration%E2%91%A5
+  return {
+    allowCustomElements: false,
+    allowElements: _removeItems(DEFAULT_ALLOWED_ELEMENTS, [
+      "basefont",
+      "command",
+      "content",
+      "data",
+      "image",
+      "plaintext",
+      "portal",
+      "slot",
+      "template",
+      "textarea",
+      "title",
+      "xmp",
+    ]),
+    allowAttributes: _removeItems(DEFAULT_ALLOWED_ATTRIBUTES, [
+      "allowpaymentrequest",
+    ]),
+  };
+};
+
+/**
+ * @param {Array} arrayToModify - array you want to remove items from
+ * @param {Array} itemsToRemove - list of elements or attributes you want to remove from arrayToModify
+ * @returns {object} - arrayToModify with all items in itemsToRemove removed from it
+ */
+const _removeItems = function _removeItems(arrayToModify, itemsToRemove) {
+  return arrayToModify.filter((element) => {
+    return !itemsToRemove.includes(element);
+  });
 };
 
 /**


### PR DESCRIPTION
From [the spec](https://wicg.github.io/sanitizer-api):
> The sanitizer has a built-in default configuration, which is stricter than the baseline and aims to eliminate any script-injection possibility, as well as legacy or unusual constructs.

Currently we are returning the baseline `allowElements` and `allowAttributes` lists instead of the [stricter default configuration](https://wicg.github.io/sanitizer-api/#ref-for-default-configuration%E2%91%A5).

https://wicg.github.io/sanitizer-api/#default-configuration

> If a Sanitizer has not received an explicit configuration, for example when being constructed without any parameters, then the default configuration value is used as the configuration object.

When the user doesn't specify an explicit config, we are currently returning a config with each configuration value set to the baseline. Now, a user who hasn't specified an explicit config will have the default configuration set for them.

https://wicg.github.io/sanitizer-api/#config

![image](https://user-images.githubusercontent.com/14011954/130339670-29ec167e-a90a-4186-9640-e65c8fc13e72.png)


Note: Will rebase this PR once other PRs ship