### PR TITLE
Only remove URLs starting with "javascript:", keep all other

### DIFF
--- a/src/sanitizer.js
+++ b/src/sanitizer.js
@@ -142,6 +142,7 @@ const _transformConfig = function transformConfig(config) {
     ALLOWED_TAGS: allowElems,
     ALLOWED_ATTR: allowAttrs,
     FORBID_ATTR: dropAttrs,
+    ALLOW_UNKNOWN_PROTOCOLS: true,
   };
   if (isdropElementsSet && !isblockElementsSet) {
     // Set FORBID_CONTENTS to drop all elements in dropElements


### PR DESCRIPTION
Closes #121 

Apparently setting `ALLOW_UNKNOWN_PROTOCOLS: true` on DOMPurify was all that was needed.

Because I also wanted it to be tested, I configured jest and added some tests. It uses jsdom to run the tests inside a nodejs environment. If running tests in real browsers is prefered instead, I have some experience with cypress and playwright (between those two I would prefer playwright because its promise-based API is easier to use and it supports more browsers).

Because ESM support is still experimental in jest I needed to enable the node option `experimental-vm-modules`: 
```
"test": "NODE_OPTIONS=--experimental-vm-modules jest"
```

Setting the environment variable like this works on linux systems. If it needs to work on windows too we could use cross-env to set the environment variable.