### PR TITLE
Sanitizer should not swallow text nodes

### DIFF
--- a/src/polyfill.js
+++ b/src/polyfill.js
@@ -74,7 +74,7 @@ function setup() {
       const context = inactiveDocument.createElement(this.localName);
       context.innerHTML = input;
       sanitizeDocFragment(sanitizerObj.getConfiguration(), context);
-      this.replaceChildren(...context.children);
+      this.replaceChildren(...context.childNodes);
     };
   }
 }


### PR DESCRIPTION
Replace `childNodes` instead of `children`. This hopefully fixes #141