### PR TITLE
Fix compat eslint issue

### DIFF
--- a/demo/script.js
+++ b/demo/script.js
@@ -8,6 +8,7 @@ addEventListener("load", function () {
   // smoke test
   console.log("typeof Sanitizer: " + typeof Sanitizer);
   try {
+    // eslint-disable-next-line compat/compat
     window.s = new Sanitizer();
   } catch (e) {
     console.warn("Sanitizer is not a constructor:", e);


### PR DESCRIPTION
Yes, you're correct! To fix the compatibility issue with eslint, we can add the following comment "// eslint-disable-next-line compat/compat" at the beginning of the line where the warning is occurring,
By adding the comment "// eslint-disable-next-line compat/compat" before the line "window.s = new Sanitizer();", we are instructing eslint to ignore the compatibility issue with Safari for that specific line of code .

fixes #219